### PR TITLE
Remove "--fail" arg for "curl" wherever it is used. Fixes #1.

### DIFF
--- a/test/integration/default/bats/apt-cacher-ng.bats
+++ b/test/integration/default/bats/apt-cacher-ng.bats
@@ -21,7 +21,7 @@ setup() {
 }
 
 @test "Hitting the apt-cacher proxy on the proxy port should succeed" {
-    run curl --fail -sS http://localhost:3142/$PACKAGE_SERVER
+    run curl -sS http://localhost:3142/$PACKAGE_SERVER
     [ "$status" -eq 0 ]
 }
 

--- a/test/integration/default/bats/devpi.bats
+++ b/test/integration/default/bats/devpi.bats
@@ -12,12 +12,12 @@ setup() {
 }
 
 @test "Accessing the devpi server on port 3141 should return a valid JSON response" {
-    run bash -c "curl --fail -sSq http://localhost:3141/ | python -m json.tool"
+    run bash -c "curl -sSq http://localhost:3141/ | python -m json.tool"
     [ "$status" -eq 0 ]
 }
 
 @test "Accessing the devpi server via the nginx vhost should return a valid JSON response" {
-    run bash -c "curl --fail -sSq -H 'Host: devpi' http://localhost/ | python -m json.tool"
+    run bash -c "curl -sSq -H 'Host: devpi' http://localhost/ | python -m json.tool"
     [ "$status" -eq 0 ]
 }
 

--- a/test/integration/default/bats/docker-registry.bats
+++ b/test/integration/default/bats/docker-registry.bats
@@ -12,18 +12,18 @@ setup() {
 }
 
 @test "The vhost for the docker registry should be available" {
-    run curl --fail -sSq -H 'Host: registry' http://localhost
+    run curl -sSq -H 'Host: registry' http://localhost
     [ "$status" -eq 0 ]
     [[ "$output" =~ "docker-registry server" ]]
 }
 
 @test "The docker registry's /_ping url should return valid JSON" {
-    run bash -c "curl --fail -sSq -H 'Host: registry' http://localhost/_ping | python -m json.tool"
+    run bash -c "curl -sSq -H 'Host: registry' http://localhost/_ping | python -m json.tool"
     [ "$status" -eq 0 ]
 }
 
 @test "The docker registry's /v1/_ping url should return valid JSON" {
-    run bash -c "curl --fail -sSq -H 'Host: registry' http://localhost/v1/_ping | python -m json.tool"
+    run bash -c "curl -sSq -H 'Host: registry' http://localhost/v1/_ping | python -m json.tool"
     [ "$status" -eq 0 ]
 }
 

--- a/test/integration/default/bats/front-end-server.bats
+++ b/test/integration/default/bats/front-end-server.bats
@@ -8,13 +8,13 @@ setup() {
 }
 
 @test "The front-end serer's root url should return http 204" {
-    run curl --fail -sSD - http://localhost/
+    run curl -sSD - http://localhost/
     [ "$status" -eq 0 ]
     [[ "$output" =~ "HTTP/1.1 204 No Content" ]]
 }
 
 @test "The front-end server's /_status location should return statistics from our web server" {
-    run curl --fail -sSD - http://localhost/_status
+    run curl -sSD - http://localhost/_status
 
     [ "$status" -eq 0 ]
     [[ "$output" =~ "HTTP/1.1 200 OK" ]]

--- a/test/integration/default/bats/http-caching-proxy.bats
+++ b/test/integration/default/bats/http-caching-proxy.bats
@@ -20,12 +20,12 @@ setup() {
 # that our nginx vhost is adding for us to be able to debug the cache status :)
 #
 @test "Accessing http://www.google.com through our proxy should always return a cache miss" {
-    run curl --fail -sI http://www.google.com
+    run curl -sI http://www.google.com
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Cache-Control: private" ]]
 
     for i in $(seq 1 5); do
-        run curl --fail -sSq -I --proxy $HTTP_PROXY_URL http://www.google.com/
+        run curl -sSq -I --proxy $HTTP_PROXY_URL http://www.google.com/
         [ "$status" -eq 0 ]
         [[ "$output" =~ "X-Cache-Status: MISS" ]]
     done
@@ -46,14 +46,14 @@ ISO_URL="$PROTOCOL://$PROTOCOL_RELATIVE_DOWNLOAD_URL"
     run curl -sSD - -o /dev/null http://localhost:1080/purge/$PROTOCOL_RELATIVE_DOWNLOAD_URL
     [ "$status" -eq 0 ]
 
-    run curl --fail --proxy $HTTP_PROXY_URL -sSD - -o /dev/null $ISO_URL
+    run curl --proxy $HTTP_PROXY_URL -sSD - -o /dev/null $ISO_URL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "HTTP/1.1 200 OK" ]]
     [[ "$output" =~ "X-Cache-Status: MISS" ]]
 }
 
 @test "Downloading a file that is in the cache should result in a cache hit" {
-    run curl --fail --proxy $HTTP_PROXY_URL -sSD - -o /dev/null $ISO_URL
+    run curl --proxy $HTTP_PROXY_URL -sSD - -o /dev/null $ISO_URL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "HTTP/1.1 200 OK" ]]
     regex="X-Cache-Status: HIT"
@@ -61,7 +61,7 @@ ISO_URL="$PROTOCOL://$PROTOCOL_RELATIVE_DOWNLOAD_URL"
 }
 
 @test "Setting the header 'X-Refresh: true' should result in a bypass of the cache" {
-    run curl --fail --proxy $HTTP_PROXY_URL -H 'X-Refresh: true' -sSD - -o /dev/null $ISO_URL
+    run curl --proxy $HTTP_PROXY_URL -H 'X-Refresh: true' -sSD - -o /dev/null $ISO_URL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "HTTP/1.1 200 OK" ]]
     [[ "$output" =~ "X-Cache-Status: BYPASS" ]]
@@ -69,7 +69,7 @@ ISO_URL="$PROTOCOL://$PROTOCOL_RELATIVE_DOWNLOAD_URL"
 
 @test "Trying to purge when it's not in the cache should return 404" {
     # Clear the file from the cache by hitting the "/purge" location.
-    run curl --fail -sSD - -o /dev/null \
+    run curl -sSD - -o /dev/null \
     http://localhost:1080/purge/$PROTOCOL_RELATIVE_DOWNLOAD_URL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "HTTP/1.1 200 OK" ]]
@@ -81,7 +81,7 @@ ISO_URL="$PROTOCOL://$PROTOCOL_RELATIVE_DOWNLOAD_URL"
 }
 
 @test "Downloading the file again after purging from the cache should yield a cache miss" {
-    run curl --fail --proxy $HTTP_PROXY_URL -sSD - -o /dev/null $ISO_URL
+    run curl --proxy $HTTP_PROXY_URL -sSD - -o /dev/null $ISO_URL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "HTTP/1.1 200 OK" ]]
     [[ "$output" =~ "X-Cache-Status: MISS" ]]

--- a/test/integration/default/bats/yum-repo.bats
+++ b/test/integration/default/bats/yum-repo.bats
@@ -12,7 +12,7 @@ setup() {
 }
 
 @test "The yum repo's vhost should return HTTP 200" {
-    run curl --fail -sSq -I -H 'Host: yum' http://localhost
+    run curl -sSq -I -H 'Host: yum' http://localhost
     [ "$status" -eq 0 ]
     [[ "$output" =~ "HTTP/1.1 200 OK" ]]
 }


### PR DESCRIPTION
- Tests still pass:
  
  ```
  -----> Running bats test suite
  ✓ Accessing the apt-cacher-ng vhost should load the configuration page for Apt-Cacher-NG
  ✓ Hitting the apt-cacher proxy on the proxy port should succeed
  ✓ The previous command that hit ftp.debian.org should have placed some files in the cache
  ✓ Accessing the devpi server on port 3141 should return a valid JSON response
  ✓ Accessing the devpi server via the nginx vhost should return a valid JSON response
  ✓ Downloading a Python package via our PyPI proxy should succeed
  ✓ We should still be able to install Python packages when the devpi contianer's backend is broken
  ✓ The vhost for the docker registry should be available
  ✓ The docker registry's /_ping url should return valid JSON
  ✓ The docker registry's /v1/_ping url should return valid JSON
  ✓ We should be able to push images to the private registry
  ✓ The front-end serer's root url should return http 204
  ✓ The front-end server's /_status location should return statistics from our web server
  ✓ Accessing http://www.google.com through our proxy should always return a cache miss
  ✓ Downloading a file that is not in the cache should result in a cache miss
  ✓ Downloading a file that is in the cache should result in a cache hit
  ✓ Setting the header 'X-Refresh: true' should result in a bypass of the cache
  ✓ Trying to purge when it's not in the cache should return 404
  ✓ Downloading the file again after purging from the cache should yield a cache miss
  ✓ The yum repo's vhost should return HTTP 200
  
       20 tests, 0 failures
       Finished verifying <default-ubuntu-1404> (1m5.04s).
  -----> Kitchen is finished. (8m18.03s)
  ```
- https://travis-ci.org/delphix/ansible-package-caching-proxy/builds/88882351
